### PR TITLE
Add Token dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,25 @@ app.register(UniversalLoggerConfigToken, config);
 #### Dependency registration
 
 ```js
-import UniversalLogger, {UniversalLoggerToken} from 'fusion-plugin-universal-logger';
-import UniversalEvents from 'fusion-plugin-universal-events';
+import UniversalEvents, {UniversalEventsToken} from 'fusion-plugin-universal-events';
+import {UniversalLoggerConfigToken} from 'fusion-plugin-universal-logger';
 
-app.register(UniversalLoggerToken, UniversalLogger);
 app.register(UniversalEventsToken, UniversalEvents);
 app.register(UniversalLoggerConfigToken, config);
 ```
 
-- `UniversalLogger` - the logger implementation
-- `UniversalEvents` - an universal event emitter. Used internally to upload logs from the browser to the server
-- `config` - a Winston config object
+##### Required dependencies
+
+Name | Type | Description
+-|-|-
+`UniversalEventsToken` | `UniversalEvents` | An event emitter plugin, such as the one provided by [`fusion-plugin-universal-events`](https://github.com/fusionjs/fusion-plugin-universal-events).
+
+##### Optional dependencies
+
+Name | Type | Default | Description
+-|-|-|-
+`UniversalLoggerConfigToken` | `WinstonConfig` | `undefined` | A [Winston](https://github.com/winstonjs/winston) configuration object.
+
 
 #### Instance methods
 


### PR DESCRIPTION
Fixes #61   | Rendered: [link](https://github.com/AlexMSmithCA/fusion-plugin-universal-logger/blob/14bbfa430e75755104f91d3e3ef2dd3fc55cf678/README.md)

> #### Problem/Rationale
> 
> Documentation regarding Fusion API is out of date given recent changes to leverage new Dependency Injection architecture. 
> 
> #### Solution/Change/Deliverable
> 
> Update documentation