### PR TITLE
Release v1.0.4-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "fusion-plugin-universal-logger",
-  "description": "A logger utility that batches logs from the browser to the server at set intervals.",
-  "version": "1.0.3",
+  "description":
+    "A logger utility that batches logs from the browser to the server at set intervals.",
+  "version": "1.0.4-0",
   "repository": "fusionjs/fusion-plugin-universal-logger",
   "keywords": [],
   "license": "MIT",
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "browser": {
@@ -55,7 +53,8 @@
     "lint": "eslint . --ignore-path .gitignore",
     "transpile": "npm run clean && cup build",
     "build-test": "rm -rf dist-test && cup build-tests",
-    "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
+    "just-test":
+      "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",
     "test": "npm run build-test && npm run just-test",
     "cover": "nyc npm test",
     "prepublish": "npm run transpile"


### PR DESCRIPTION
This does encapsulate a winston release under the hood, but I think that this technically should not be a breaking change. Previously we were just not using the correct log levels at all according to the winston docs, see: https://github.com/fusionjs/fusion-plugin-universal-logger/pull/118/files#diff-04c6e90faac2675aa89e2176d2eec7d8L117