### PR TITLE
Add immediate batch flushing after error logs

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -51,13 +51,19 @@ const plugin =
           });
         }
         log(level, ...args) {
-          return emitter.emit('universal-log', {
+          emitter.emit('universal-log', {
             level,
             args: args.map(normalizeErrors),
           });
+
+          // send errors immediately instead of batching to prevent
+          // unwieldy batch sizes
+          if (level === 'error') {
+            // $FlowFixMe
+            emitter.flush().catch(error => this.log('error', error));
+          }
         }
       }
-      // $FlowFixMe
       return new UniversalLogger();
     },
   });


### PR DESCRIPTION
> send errors immediately instead of batching to prevent unwieldy batch sizes