### PR TITLE
Update server plugin to pass all logs through event emitter

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -54,6 +54,7 @@ const plugin =
           emitter.emit('universal-log', {
             level,
             args: args.map(normalizeErrors),
+            source: 'browser',
           });
 
           // send errors immediately instead of batching to prevent

--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,7 @@ const plugin =
         if (typeof logger[key] === 'function') {
           // $FlowFixMe
           UniversalLogger.prototype[key] = (...args) =>
-            emitter.emit('universal-log', {args, level: key});
+            emitter.emit('universal-log', {args, level: key, source: 'server'});
         }
       }
       return new UniversalLogger();

--- a/src/server.js
+++ b/src/server.js
@@ -33,7 +33,8 @@ const plugin =
       for (const key in logger) {
         if (typeof logger[key] === 'function') {
           // $FlowFixMe
-          UniversalLogger.prototype[key] = (...args) => logger[key](...args);
+          UniversalLogger.prototype[key] = (...args) =>
+            emitter.emit('universal-log', {args, level: key});
         }
       }
       return new UniversalLogger();


### PR DESCRIPTION
Currently the event emitter channel is only used to transmit from browser to server. This changes it to use the emitter for both browser and server logs.

This allows for the entire log channel to be listened to by other plugins (e.g. for metrics)